### PR TITLE
Support a different return topic for publishAndWait

### DIFF
--- a/src/main/scala/com/github/jeanadrien/gatling/mqtt/actions/PublishAndWaitAction.scala
+++ b/src/main/scala/com/github/jeanadrien/gatling/mqtt/actions/PublishAndWaitAction.scala
@@ -26,6 +26,7 @@ class PublishAndWaitAction(
     qos             : MqttQoS,
     retain          : Boolean,
     timeout         : FiniteDuration,
+    returnTopic     : String,
     val next        : Action
 ) extends MqttAction(mqttComponents, coreComponents) {
 
@@ -55,7 +56,8 @@ class PublishAndWaitAction(
             payload = resolvedPayload,
             payloadFeedback = payloadCheck,
             qos = qos,
-            retain = retain
+            retain = retain,
+            returnTopic = returnTopic
         )).mapTo[MqttCommands] onComplete {
             case Success(MqttCommands.FeedbackReceived) =>
                 val latencyTimings = timings(requestStartDate)

--- a/src/main/scala/com/github/jeanadrien/gatling/mqtt/actions/PublishAndWaitActionBuilder.scala
+++ b/src/main/scala/com/github/jeanadrien/gatling/mqtt/actions/PublishAndWaitActionBuilder.scala
@@ -19,7 +19,8 @@ case class PublishAndWaitActionBuilder(
     payloadFeedback : Array[Byte] => Array[Byte] => Boolean = PayloadComparison.sameBytesContent,
     qos             : MqttQoS = MqttQoS.AtMostOnce,
     retain          : Boolean = false,
-    timeout         : FiniteDuration = 60 seconds
+    timeout         : FiniteDuration = 60 seconds,
+    returnTopic     : String = ""
 ) extends MqttActionBuilder {
 
     def qos(newQos : MqttQoS) : PublishAndWaitActionBuilder = this.modify(_.qos).setTo(newQos)
@@ -31,6 +32,8 @@ case class PublishAndWaitActionBuilder(
     def qosExactlyOnce = qos(MqttQoS.ExactlyOnce)
 
     def retain(newRetain : Boolean) : PublishAndWaitActionBuilder = this.modify(_.retain).setTo(newRetain)
+
+    def returnTopic(newTopic: String) : PublishAndWaitActionBuilder = this.modify(_.returnTopic).setTo(newTopic)
 
     def payloadFeedback(fn : Array[Byte] => Array[Byte] => Boolean) : PublishAndWaitActionBuilder = this
         .modify(_.payloadFeedback).setTo(fn)
@@ -49,6 +52,7 @@ case class PublishAndWaitActionBuilder(
             qos,
             retain,
             timeout,
+            returnTopic,
             next
         )
     }

--- a/src/main/scala/com/github/jeanadrien/gatling/mqtt/client/MqttCommands.scala
+++ b/src/main/scala/com/github/jeanadrien/gatling/mqtt/client/MqttCommands.scala
@@ -26,7 +26,7 @@ object MqttCommands {
     case class OnPublish(topic : String, payload : Array[Byte]) extends MqttCommands
 
     case class PublishAndWait(
-        topic : String, payload : Array[Byte], payloadFeedback : FeedbackFunction, qos : MqttQoS, retain : Boolean
+        topic : String, payload : Array[Byte], payloadFeedback : FeedbackFunction, qos : MqttQoS, retain : Boolean, returnTopic: String
     ) extends MqttCommands
 
     case class PublishAckRegisterFeedback(


### PR DESCRIPTION
This adds the ability to specify a second topic on which to expect the "echoed" events.